### PR TITLE
Fixing lightmode for keyscreator

### DIFF
--- a/src/components/CreateKeyModal/CreateKeyModal.tsx
+++ b/src/components/CreateKeyModal/CreateKeyModal.tsx
@@ -284,7 +284,7 @@ export const CreateKeyModal: FC<{ onClose: () => void }> = ({ onClose }) => {
                     <div className="flex mt-2">
                         <input
                             id="generated_token"
-                            className="p-2 bg-black-500 w-full block overflow-hidden"
+                            className="p-2 dark:bg-black-500 bg-slate-300 w-full block overflow-hidden"
                             value={generatedToken}
                         />
                         <button


### PR DESCRIPTION
The problem:
![image](https://user-images.githubusercontent.com/84264740/185183117-832b527f-3a3c-4723-ad90-9becb236074f.png)
The solution:
![image](https://user-images.githubusercontent.com/84264740/185183012-3d17136c-6890-45a7-a2c0-f5ba96535909.png)

The auth keys shown in screenshots are not active nor fully shown.
